### PR TITLE
Fix Ticker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tina",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Tweening and INterpolations for Animation",
   "main": "src/index.js",
   "scripts": {

--- a/src/Ticker.js
+++ b/src/Ticker.js
@@ -17,6 +17,7 @@ function Ticker(tupt) {
 	// Time units per tick (tupt)
 	// Every second, 'tupt' time units elapse
 	this.tupt = tupt || 1;
+	this._nbTicks = 0;
 
 }
 Ticker.prototype = Object.create(Tweener.prototype);


### PR DESCRIPTION
Not having `this._nbTicks` defined in the constructor made the `Ticker` to have its time becoming `NaN`

fixes #45 
