### PR TITLE
Fixed on lost focus functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tina",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "Tweening and INterpolations for Animation",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tina",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Tweening and INterpolations for Animation",
   "main": "src/index.js",
   "scripts": {

--- a/src/Delay.js
+++ b/src/Delay.js
@@ -5,13 +5,17 @@ var BriefPlayable = require('./BriefPlayable');
  * Manages tweening of one property or several properties of an object
  */
 
-function Delay(duration) {
+function Delay(duration, onComplete) {
 	if ((this instanceof Delay) === false) {
 		return new Delay(duration);
 	}
 
 	BriefPlayable.call(this);
 	this._duration = duration;
+
+	if (onComplete !== undefined) {
+		this.onComplete(onComplete);
+	}
 }
 Delay.prototype = Object.create(BriefPlayable.prototype);
 Delay.prototype.constructor = Delay;

--- a/src/TINA.js
+++ b/src/TINA.js
@@ -95,6 +95,10 @@ var TINA = {
 	},
 
 	update: function () {
+		if (this._running === false) {
+			return;
+		}
+
 		var now = clock.now() - this._startTime;
 		var dt = now - this._time;
 		if (dt < 0) {
@@ -209,7 +213,6 @@ var TINA = {
 	// Internal stop method, called by stop and pause
 	_stopAutomaticUpdate: function () {
 		if (this._running === false) {
-			console.warn('[TINA.pause] TINA is not running');
 			return false;
 		}
 
@@ -219,31 +222,20 @@ var TINA = {
 	},
 
 	pause: function () {
-		if (this._stopAutomaticUpdate() === false) {
-			return;
-		}
-
-		for (var handle = this._activeTweeners.first; handle !== null; handle = handle.next) {
-			handle.object._pause();
-		}
-
+		this._running = false;
 		if (this._onPause !== null) {
 			this._onPause();
 		}
+
 		return this;
 	},
 
 	resume: function () {
-		if (this._startAutomaticUpdate() === false) {
-			return;
-		}
+		this._running = true;
+		this._startTime = clock.now() - this._time;
 
 		if (this._onResume !== null) {
 			this._onResume();
-		}
-
-		for (var handle = this._activeTweeners.first; handle !== null; handle = handle.next) {
-			handle.object._resume();
 		}
 
 		return this;

--- a/src/TINA.js
+++ b/src/TINA.js
@@ -59,6 +59,7 @@ var TINA = {
 	_time:      0,
 
 	_running: false,
+	_paused: false,
 
 	// callbacks
 	_onStart:  null,
@@ -95,7 +96,7 @@ var TINA = {
 	},
 
 	update: function () {
-		if (this._running === false) {
+		if (this._paused) {
 			return;
 		}
 
@@ -222,7 +223,7 @@ var TINA = {
 	},
 
 	pause: function () {
-		this._running = false;
+		this._paused = true;
 		if (this._onPause !== null) {
 			this._onPause();
 		}
@@ -231,7 +232,7 @@ var TINA = {
 	},
 
 	resume: function () {
-		this._running = true;
+		this._paused = false;
 		this._startTime = clock.now() - this._time;
 
 		if (this._onResume !== null) {


### PR DESCRIPTION
Pausing on lost focus then resuming on  was making TINA update twice every frame. It was due to the onRequestAnimationFrame callback not being removed.
