### PR TITLE
Fix: TINA was writing to the global object by mistake

### DIFF
--- a/src/TINA.js
+++ b/src/TINA.js
@@ -204,7 +204,7 @@ var TINA = {
 
 		function updateTINA() {
 			TINA.update();
-			this._requestFrameId = requestAnimFrame(updateTINA);
+			TINA._requestFrameId = requestAnimFrame(updateTINA);
 		}
 
 		this.reset();


### PR DESCRIPTION
Fixes #55 

- `window._requestFrameId` was continuously being written to
- `TINA._requestFrameId` was not being updated, so could not be cancelled

This PR resolves that. Testing for the existence of this bug is as easy as looking at those 2 properties.

## Impact of the bug:

Afaik in strict mode, the global object is not `window`, but `undefined`, which causes Tina to completely break. It will be writing `_requestFrameId` to `undefined`, which throws.

## Impact of the fix:

Hopefully no side-effects. Use of `_requestFrameId` is minimal, so it seems it should be safe, but serious testing would be good.